### PR TITLE
Add missing alpha to equality sign

### DIFF
--- a/lection-01.tex
+++ b/lection-01.tex
@@ -174,7 +174,7 @@ $$\Lambda ::= (\lambda x.\Lambda) | (\Lambda\ \Lambda) | x$$
 	\begin{enumerate}
 		\item $A=B$
 		\item $A=P_{1}\ Q_{1}$, $B=P_{2}\ Q_{2}$ и $P_{1}\bpar P_{2}$, $Q_{1}\bpar Q_{2}$
-		\item $A=\lambda{}x.P_{1}$, $B=\lambda{}x.P_{2}$ и 
+		\item $A=_{\alpha}\lambda{}x.P_{1}$, $B=_{\alpha}\lambda{}x.P_{2}$ и 
 		$P_{1}\bpar P_{2}$
 		\item $A=_{\alpha}(\lambda{}x.P_1)Q_1$, $B=_{\alpha}P_2[x\coloneqq{}Q_2]$, причем $Q_2$ свободна для подстановки вместо $x$ в $P_2$ и $P_1 \bpar P_2$, $Q_1 \bpar Q_2$
 	\end{enumerate}


### PR DESCRIPTION
Пропущена `\alpha`, ведь имеется ввиду альфа-эквивалентность, как и в следующем пункте.